### PR TITLE
Fix: Correct pubDate format in blog creation script

### DIFF
--- a/scripts/create_blog.sh
+++ b/scripts/create_blog.sh
@@ -11,7 +11,7 @@ fi
 # init vars
 title=$title
 description="description"
-pubDate=$(date +"%b' '%d' '%Y")
+pubDate=$(date +"%b %d %Y")
 blogID=$(bun scripts/ulid.ts)
 heroImage="/og/${title}.png"
 migration_name="insert_blog_$blogID"


### PR DESCRIPTION
## Summary
- Fixed incorrect quotation marks in the pubDate format string in `scripts/create_blog.sh`
- Changed from `date +"%b' '%d' '%Y"` to `date +"%b %d %Y"` 
- This resolves the issue where generated markdown files had malformed dates with stray quotation marks

## Test plan
- [x] Run `make blog/new` locally to create a new blog post
- [x] Verify the pubDate field in the generated markdown file has the correct format (e.g., "Nov 02 2025")
- [x] Confirm no extraneous quotation marks appear in the date

🤖 Generated with [Claude Code](https://claude.com/claude-code)